### PR TITLE
refactor: split impl of x86_64 specific code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "atty",
  "bat",
  "byteorder",
+ "cfg-if",
  "clap",
  "color-eyre",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/queer/boxxy"
 atty = "0.2.14"
 bat = { version = "0.22.1", default-features = false, features = ["atty", "regex-onig"] }
 byteorder = "1.4.3"
+cfg-if = "1.0.0"
 clap = { version = "4.1.11", features = ["derive"] }
 color-eyre = { version = "0.6.2", features = ["issue-url"] }
 config = "0.13.3"

--- a/src/enclosure/mod.rs
+++ b/src/enclosure/mod.rs
@@ -27,6 +27,7 @@ use self::rule::{BoxxyConfig, RuleMode};
 
 pub mod fs;
 mod linux;
+mod register;
 pub mod rule;
 mod syscall;
 mod tracer;

--- a/src/enclosure/register.rs
+++ b/src/enclosure/register.rs
@@ -1,0 +1,27 @@
+macro_rules! string_registers {
+    ($($t:tt)*) => {
+        #[allow(unused)]
+        #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
+        pub enum StringRegister {
+            $($t)*
+        }
+    };
+}
+
+#[cfg(target_arch = "x86_64")]
+macro_rules! syscall_number_from_user_regs {
+    ($regs: ident) => {
+        $regs.orig_rax
+    };
+}
+pub(crate) use syscall_number_from_user_regs;
+
+#[cfg(target_arch = "x86_64")]
+string_registers! {
+    Rdi,
+    Rsi,
+    Rdx,
+    Rcx,
+    R8,
+    R9,
+}

--- a/src/enclosure/syscall/mod.rs
+++ b/src/enclosure/syscall/mod.rs
@@ -1,0 +1,28 @@
+use cfg_if::cfg_if;
+use color_eyre::Result;
+use nix::unistd::Pid;
+use std::{fs, path::PathBuf};
+
+#[allow(unused)]
+fn get_fd_path(pid: Pid, fd: i32) -> Result<Option<PathBuf>> {
+    let fd_path = format!("/proc/{pid}/fd/{fd}");
+    match fs::read_link(fd_path) {
+        Ok(path) => {
+            if path.starts_with("pipe:[") {
+                Ok(None)
+            } else {
+                Ok(Some(path))
+            }
+        }
+        Err(_) => Ok(None),
+    }
+}
+
+cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        mod x86_64;
+        pub use x86_64::*;
+    } else {
+        compile_error!("The current architecture is unsupported!");
+    }
+}

--- a/src/enclosure/tracer.rs
+++ b/src/enclosure/tracer.rs
@@ -10,6 +10,7 @@ use nix::sys::signal::Signal;
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::Pid;
 
+use super::register::{syscall_number_from_user_regs, StringRegister};
 use super::syscall::Syscall;
 
 pub struct Tracer {
@@ -228,7 +229,7 @@ impl Tracer {
         let regs = child.get_registers()?;
         trace!(
             "child {pid} exited syscall {:?}",
-            syscall_numbers::native::sys_call_name(regs.orig_rax as i64)
+            syscall_numbers::native::sys_call_name(syscall_number_from_user_regs!(regs) as i64)
         );
         Ok(())
     }
@@ -324,15 +325,4 @@ pub enum ChildProcessState {
     EnteringSyscall,
     ExitingSyscall,
     PtraceEvent,
-}
-
-#[allow(unused)]
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, PartialOrd, Ord)]
-pub enum StringRegister {
-    Rdi,
-    Rsi,
-    Rdx,
-    Rcx,
-    R8,
-    R9,
 }


### PR DESCRIPTION
Separate x86_64 specific code from the rest of the code base to make it easier for porting this useful app to other architectures.