### PR TITLE
docs: add newuidmap req

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ git:(mistress) | ▶
 - stop using symlinks!!!
 - no more dev config files when writing code
 
+## requirements
+
+boxxy requires `newuidmap` to function, which is not included by default in all
+distributions. To install:
+
+Alpine:
+```sh
+$ apk add shadow-uidmap
+```
+
+Debian / Ubuntu:
+```sh
+$ apt install uidmap
+```
+
+RHEL / Fedora:
+```sh
+$ yum install shadow-utils
+```
+
 ## configuration
 
 The boxxy configuration file lives in `~/.config/boxxy/boxxy.yaml`. If none


### PR DESCRIPTION
boxxy requires `newuidmap` to function, which is not included by default in all distributions. If the command doesn't exist, the end user will receive an unclear error message:

```
Error:
   0: No such file or directory (os error 2)

Location:
   src/enclosure/linux.rs:21
```

This PR adds the `newuidmap` requirement to the README file.