### PR TITLE
Reverse order of self.created_directories during clean up

### DIFF
--- a/src/enclosure/mod.rs
+++ b/src/enclosure/mod.rs
@@ -378,7 +378,7 @@ impl Enclosure {
             debug!("removing temporary file {}", file.display());
             std::fs::remove_file(file)?;
         }
-        for dir in &self.created_directories {
+        for dir in (&self.created_directories).iter().rev() {
             debug!("removing temporary directory {}", dir.display());
             std::fs::remove_dir(dir)?;
         }


### PR DESCRIPTION
boxxy will fail to exit properly with nested rules, because it deletes the created directories in the same order they were created (ex. if it creates .mozilla first followed by .mozilla/extensions, it will try to delete .mozilla first, which will fail because the directory is not empty, even though boxxy created the subdirectory). This is a one-line fix to the cleanup process that has been tested on my system.