### PR TITLE
fix: parse RuleMode::Directory from 'dir' as well as 'directory'

### DIFF
--- a/src/enclosure/rule.rs
+++ b/src/enclosure/rule.rs
@@ -206,7 +206,7 @@ impl FromStr for RuleMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "file" => Ok(RuleMode::File),
-            "directory" => Ok(RuleMode::Directory),
+            "directory" | "dir" => Ok(RuleMode::Directory),
             _ => Err(format!("invalid rule mode: {}", s)),
         }
     }


### PR DESCRIPTION
Hello,

The help message shows
```
 -r, --rule <ARG_RULES>
          Pass rules via CLI. -r/--rule `/remount/this:/to/this:<file/dir>`
```
which lead me to believe I should write `dir` instead of `directory` as the file mode. Eventually I figured out that only `directory` is acceptable.

This is a quick PR allows parsing either 'dir' or 'directory'. If you would rather not accept this PR, please consider updating the help message to spell out the full word `directory`