### PR TITLE
main.rs: fix incorrect documentation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ pub struct Args {
     #[arg(
         short = 'r',
         long = "rule",
-        help = "Pass rules via CLI. -r/--rule `/remount/this:/to/this:<file/dir>`",
+        help = "Pass rules via CLI. -r/--rule `/remount/this:/to/this:<file/directory>`",
         action = ArgAction::Append
     )]
     pub arg_rules: Vec<String>,


### PR DESCRIPTION
`dir` returns an error while `directory` redirects to a directory